### PR TITLE
Fix GitHub Pages runtime rendering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
           npm ci
           export VUE_APP_PUBLIC_PATH=/ionic-vue-boilerplate/
           npm run build
+          cp dist/index.html dist/404.html
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4

--- a/src/components/inputs/SelectExample.vue
+++ b/src/components/inputs/SelectExample.vue
@@ -33,7 +33,7 @@
       @click="cleanSelect()"
     />
   </ion-item>
-  <error-message class="mt-1" :text="errors.value" />
+  <ErrorMessage class="mt-1" :text="errors.value" />
 </template>
 
 <script setup>
@@ -42,6 +42,7 @@ import { IonSelect, IonSelectOption, IonItem } from "@ionic/vue";
 import { onMounted, ref, defineProps, defineEmits, toRefs, watch } from "vue";
 
 import Button from "../Button.vue";
+import ErrorMessage from "../ErrorMessage.vue";
 
 const emit = defineEmits(["update:modelValue"]);
 


### PR DESCRIPTION
## What changed

- imports `ErrorMessage` explicitly in `SelectExample` so Vue 3.5 does not resolve the `errorMessage` prop value as a dynamic HTML tag
- publishes the built `index.html` as `404.html` so direct GitHub Pages routes such as `/home` bootstrap Vue Router

## Root cause

The dependency refresh moved the Vue runtime to 3.5. The `SelectExample` component had a global component name that collided with its `errorMessage` prop, causing an `InvalidCharacterError` before the application rendered.

## Validation

- production build with `VUE_APP_PUBLIC_PATH=/ionic-vue-boilerplate/`
- ESLint (no errors; one existing prop-type warning)
- browser verification of `/home`: full Ionic application rendered with no `InvalidCharacterError`